### PR TITLE
Tweak the CSS for better display of code blocks.

### DIFF
--- a/themes/pypy/assets/css/styles.css
+++ b/themes/pypy/assets/css/styles.css
@@ -17,10 +17,11 @@
 }
 
 pre.literal-block {
-  border: 0.3rem solid #d1d1d1;
   margin-left: 0;
   margin-right: 0;
   padding: 1rem 1.5rem;
+  border-top: 1px solid black;
+  border-bottom: 1px solid black;
 }
 
 pre.literal-block *:last-child {
@@ -143,14 +144,6 @@ div.sidebar {
 
 .content {
   margin: 0 auto;
-}
-
-pre.literal-block {    
-    margin: 30px;
-    text-align: center;
-    border-top: 1px solid black;
-    padding: 30px;
-    border-bottom: 1px solid black;
 }
 
 .nav-container nav {


### PR DESCRIPTION
We had two pre.literal-blocks rule, merge them into one. But most importantly,
remove the text-align: center which doesn't make sense for code blocks

See also: https://github.com/hpyproject/hpyproject.org/commit/441b14765d3eb9f7276ad27b48fc6cfa2f5bb097.

Current look of code blocks:
![image](https://user-images.githubusercontent.com/344507/112748566-c19f5380-8fbc-11eb-8e68-6da23a4c3b27.png)

Look after this PR:
![image](https://user-images.githubusercontent.com/344507/112748579-e1cf1280-8fbc-11eb-8ef2-86d986156d1d.png)
