### PR TITLE
fixup relative links

### DIFF
--- a/posts/2021/10/pypy-v736-release.txt
+++ b/posts/2021/10/pypy-v736-release.txt
@@ -82,9 +82,9 @@ making a CFFI_ / cppyy_ version of your library that would be performant on PyPy
 In any case both `cibuildwheel`_ and the `multibuild system`_ support
 building wheels for PyPy.
 
-.. _`PyPy`: index.html
+.. _`PyPy`: https://pypy.org
 .. _`RPython`: https://rpython.readthedocs.org
-.. _`help`: project-ideas.html
+.. _`help`: https://doc.pypy.org/en/latest/project-ideas.html
 .. _CFFI: https://cffi.readthedocs.io
 .. _cppyy: https://cppyy.readthedocs.io
 .. _`multibuild system`: https://github.com/matthew-brett/multibuild


### PR DESCRIPTION
The current tags gets linked to

https://www.pypy.org/posts/2021/10/index.html
https://www.pypy.org/posts/2021/10/project-ideas.html

which are non-existent pages