### PR TITLE
add a 'sponsors' tag

### DIFF
--- a/posts/2011/03/thank-you-to-psf-5934275567667314914.meta
+++ b/posts/2011/03/thank-you-to-psf-5934275567667314914.meta
@@ -1,7 +1,7 @@
 .. title: A thank you to the PSF
 .. slug: thank-you-to-psf-5934275567667314914
 .. date: 2011-03-21 23:50:00
-.. tags: 
+.. tags: sponsors
 .. description: 
 .. authors: Maciej Fijalkowski
 .. id: 5934275567667314914

--- a/posts/2013/05/pypy-20-alpha-for-arm-2318299473927531503.meta
+++ b/posts/2013/05/pypy-20-alpha-for-arm-2318299473927531503.meta
@@ -1,7 +1,7 @@
 .. title: PyPy 2.0 alpha for ARM
 .. slug: pypy-20-alpha-for-arm-2318299473927531503
 .. date: 2013-05-07 13:35:00
-.. tags: 
+.. tags: sponsors, arm
 .. description: 
 .. authors: Maciej Fijalkowski
 .. id: 2318299473927531503

--- a/posts/2014/03/pygamecffi-pygame-on-pypy-8679802461301121984.meta
+++ b/posts/2014/03/pygamecffi-pygame-on-pypy-8679802461301121984.meta
@@ -1,7 +1,7 @@
 .. title: pygame_cffi: pygame on PyPy
 .. slug: pygamecffi-pygame-on-pypy-8679802461301121984
 .. date: 2014-03-26 16:28:00
-.. tags: 
+.. tags: sponsors
 .. description: 
 .. authors: Maciej Fijalkowski
 .. id: 8679802461301121984

--- a/posts/2014/10/couchbase-contribution-to-pypy-2360892117372790069.meta
+++ b/posts/2014/10/couchbase-contribution-to-pypy-2360892117372790069.meta
@@ -1,7 +1,7 @@
 .. title: Couchbase contribution to PyPy
 .. slug: couchbase-contribution-to-pypy-2360892117372790069
 .. date: 2014-10-14 17:40:00
-.. tags: 
+.. tags: sponsors
 .. description: 
 .. authors: Maciej Fijalkowski
 .. id: 2360892117372790069

--- a/posts/2016/08/pypy-gets-funding-from-mozilla-for-5569307998787871200.meta
+++ b/posts/2016/08/pypy-gets-funding-from-mozilla-for-5569307998787871200.meta
@@ -1,7 +1,7 @@
 .. title: PyPy gets funding from Mozilla for Python 3.5 support
 .. slug: pypy-gets-funding-from-mozilla-for-5569307998787871200
 .. date: 2016-08-09 16:38:00
-.. tags: 
+.. tags: sponsors
 .. description: 
 .. authors: Armin Rigo
 .. id: 5569307998787871200

--- a/posts/2017/06/pypy-v58-released-739876359584854017.meta
+++ b/posts/2017/06/pypy-v58-released-739876359584854017.meta
@@ -1,7 +1,7 @@
 .. title: PyPy v5.8 released
 .. slug: pypy-v58-released-739876359584854017
 .. date: 2017-06-08 23:20:00
-.. tags: release
+.. tags: release, sponsors
 .. description: 
 .. authors: mattip
 .. id: 739876359584854017

--- a/posts/2019/01/pypy-for-low-latency-systems-613165393301401965.meta
+++ b/posts/2019/01/pypy-for-low-latency-systems-613165393301401965.meta
@@ -1,7 +1,7 @@
 .. title: PyPy for low-latency systems
 .. slug: pypy-for-low-latency-systems-613165393301401965
 .. date: 2019-01-03 14:21:00
-.. tags: 
+.. tags: gc, sponsors
 .. description: 
 .. authors: Antonio Cuni
 .. id: 613165393301401965


### PR DESCRIPTION
I added a 'sponsors' tag to older blog posts that mention sponsored work.