### PR TITLE
Change some blogpost links from bitbucket

### DIFF
--- a/posts/2017/10/cape-of-good-hope-for-pypy-hello-from-3656631725712879033.html
+++ b/posts/2017/10/cape-of-good-hope-for-pypy-hello-from-3656631725712879033.html
@@ -110,6 +110,6 @@ Our sprint venue today <a href="https://twitter.com/hashtag/pypy?src=hash&amp;re
 
 <br>
 <table align="center" cellpadding="0" cellspacing="0" class="tr-caption-container" style="float: left; margin-right: 1em; text-align: left;"><tbody>
-<tr><td style="text-align: center;"><a href="https://bytebucket.org/pypy/extradoc/raw/extradoc/sprintinfo/cape-town-2017/2017-10-04-155524.jpg" style="margin-left: auto; margin-right: auto;"><img border="0" height="360" src="https://bytebucket.org/pypy/extradoc/raw/extradoc/sprintinfo/cape-town-2017/2017-10-04-155524.jpg" width="640"></a></td></tr>
+<tr><td style="text-align: center;"><a href="https://foss.heptapod.net/pypy/extradoc/-/blob/branch/extradoc/sprintinfo/cape-town-2017/2017-10-04-155524.jpg" style="margin-left: auto; margin-right: auto;"><img border="0" height="360" src="https://bytebucket.org/pypy/extradoc/raw/extradoc/sprintinfo/cape-town-2017/2017-10-04-155524.jpg" width="640"></a></td></tr>
 <tr><td class="tr-caption" style="text-align: center;">The panorama we looked at instead of staring at cpyext code</td></tr>
 </tbody></table></body></html>

--- a/posts/2017/10/cape-of-good-hope-for-pypy-hello-from-3656631725712879033.html
+++ b/posts/2017/10/cape-of-good-hope-for-pypy-hello-from-3656631725712879033.html
@@ -65,7 +65,7 @@ To reach this result, we did various improvements, such as:
 slow logic;</li>
 <li>implement freelists to allocate the cpyext versions of <tt class="docutils literal">int</tt> and
 <tt class="docutils literal">tuple</tt> objects, as CPython does;</li>
-<li>the <a class="reference external" href="https://bitbucket.org/pypy/pypy/commits/branch/cpyext-avoid-roundtrip">cpyext-avoid-roundtrip</a> branch: crossing the RPython/C border is
+<li>the <a class="reference external" href="https://foss.heptapod.net/pypy/pypy/-/merge_requests/573">cpyext-avoid-roundtrip</a> branch: crossing the RPython/C border is
 slowish, but the real problem was (and still is for many cases) we often
 cross it many times for no good reason. So, depending on the actual API
 call, you might end up in the C land, which calls back into the RPython

--- a/posts/2017/10/cape-of-good-hope-for-pypy-hello-from-3656631725712879033.meta
+++ b/posts/2017/10/cape-of-good-hope-for-pypy-hello-from-3656631725712879033.meta
@@ -1,7 +1,7 @@
 .. title: (Cape of) Good Hope for PyPy
 .. slug: cape-of-good-hope-for-pypy-hello-from-3656631725712879033
 .. date: 2017-10-18 13:31:00
-.. tags: sprint,unicode,cpyext
+.. tags: sprint,unicode,cpyext,profile,speed
 .. description: 
 .. authors: Antonio Cuni
 .. id: 3656631725712879033

--- a/posts/2017/10/how-to-make-your-code-80-times-faster-1424098117108093942.html
+++ b/posts/2017/10/how-to-make-your-code-80-times-faster-1424098117108093942.html
@@ -109,7 +109,7 @@ this is loop in which we spend most of the time, and it is composed of 1796
 operations.  The operations emitted for the line <tt class="docutils literal"><span class="pre">np.dot(...)</span> +
 self.constant</tt> are listed between lines 1217 and 1456. Here is the excerpt
 which calls <tt class="docutils literal"><span class="pre">np.dot(...)</span></tt>; most of the ops are cheap, but at line 1232 we
-see a call to the RPython function <a class="reference external" href="https://bitbucket.org/pypy/pypy/src/89d1f31fabc86778cfaa1034b1102887c063de66/pypy/module/micronumpy/ndarray.py?at=default&amp;fileviewer=file-view-default#ndarray.py-1168">descr_dot</a>; by looking at the
+see a call to the RPython function <a class="reference external" href="https://foss.heptapod.net/pypy/pypy/-/blob/release-pypy3.5-v5.10.0/pypy/module/micronumpy/ndarray.py#L1160">descr_dot</a>; by looking at the
 implementation we see that it creates a new <tt class="docutils literal">W_NDimArray</tt> to store the
 result, which means it has to do a <tt class="docutils literal">malloc()</tt>:<br>
 <div class="separator" style="clear: both; text-align: center;">

--- a/posts/2017/10/how-to-make-your-code-80-times-faster-1424098117108093942.html
+++ b/posts/2017/10/how-to-make-your-code-80-times-faster-1424098117108093942.html
@@ -72,7 +72,7 @@ Generation   3: ... [population = 500]  [34.21 secs]
 Generation   4: ... [population = 500]  [33.75 secs]
 </pre>
 Ouch! We are ~5.5x slower than CPython. This was kind of expected: numpy is
-based on cpyext, which is infamously slow.  (Actually, <a class="reference external" href="https://morepypy.blogspot.it/2017/10/cape-of-good-hope-for-pypy-hello-from.html">we are working on
+based on cpyext, which is infamously slow.  (Actually, <a class="reference external" href="https://pypy.org/posts/2017/10/cape-of-good-hope-for-pypy-hello-from-3656631725712879033.html">we are working on
 that</a> and on the <tt class="docutils literal"><span class="pre">cpyext-avoid-roundtrip</span></tt> branch we are already faster than
 CPython, but this will be the subject of another blog post.)<br>
 <br>

--- a/posts/2017/10/how-to-make-your-code-80-times-faster-1424098117108093942.meta
+++ b/posts/2017/10/how-to-make-your-code-80-times-faster-1424098117108093942.meta
@@ -1,7 +1,7 @@
 .. title: How to make your code 80 times faster
 .. slug: how-to-make-your-code-80-times-faster-1424098117108093942
 .. date: 2017-10-30 10:15:00
-.. tags: 
+.. tags: jit, profiling, speed
 .. description: 
 .. authors: Antonio Cuni
 .. id: 1424098117108093942

--- a/posts/2018/09/the-first-15-years-of-pypy-3412615975376972020.html
+++ b/posts/2018/09/the-first-15-years-of-pypy-3412615975376972020.html
@@ -185,7 +185,7 @@ programming, constraint programming, and so on. Unfortunately it
 turned out that those things then have to be implemented, which can be called
 the first thing we learned: if you promise something to the EU, you'll have to
 actually go do it (After the funding ended, a lot of these features were
-actually removed from the project again, at a <a class="reference external" href="https://morepypy.blogspot.com/2007/11/sprint-pictures.html">cleanup sprint</a>).</p>
+actually removed from the project again, at a <a class="reference external" href="https://www.pypy.org/posts/2007/11/sprint-pictures.html">cleanup sprint</a>).</p>
 </div>
 
 
@@ -329,9 +329,9 @@ what those ideas are for.</p>
 feedback. Runtime feedback is most commonly used to know something about which
 concrete types are used by a program in practice. Promote is basically a way to
 easily introduce runtime feedback into the JIT produced by the JIT generator.
-It's an <a class="reference external" href="https://morepypy.blogspot.com/2011/03/controlling-tracing-of-interpreter-with_15.html">annotation</a> the implementer of a language can use to express their wish
+It's an <a class="reference external" href="https://www.pypy.org/posts/2011/03/controlling-tracing-of-interpreter-with_15.html">annotation</a> the implementer of a language can use to express their wish
 that specialization should happen at <em>this</em> point. This mechanism can be used to
-express <a class="reference external" href="https://morepypy.blogspot.com/2011/03/controlling-tracing-of-interpreter-with_21.html">all kinds of</a> runtime feedback, moving values from the interpreter
+express <a class="reference external" href="https://www.pypy.org/posts/2011/03/controlling-tracing-of-interpreter-with_21.html">all kinds of</a> runtime feedback, moving values from the interpreter
 into the compiler, whether they be types or other things.</p>
 </div>
 
@@ -387,7 +387,7 @@ together that the goal of that week should be to try to write a Squeak virtual
 machine in RPython, and at the end of the week we'd gotten surprisingly far with
 that goal. Basically most of the bytecodes and the Smalltalk object system
 worked, we had written an image loader and could run some benchmarks (during the
-sprint we also regularly updated a <a class="reference external" href="https://pypysqueak.blogspot.com/">blog</a>, the success of which led us to <a class="reference external" href="https://morepypy.blogspot.com/2007/10/first-post.html">start</a>
+sprint we also regularly updated a <a class="reference external" href="https://pypysqueak.blogspot.com/">blog</a>, the success of which led us to <a class="reference external" href="https://www.pypy.org/posts/2007/10/first-post.html">start</a>
 the PyPy blog).</p>
 
 <div class="separator" style="clear: both; text-align: center;"><a href="https://4.bp.blogspot.com/-n0Xj6fdNu-g/W5UZE-Z0O8I/AAAAAAAAlFM/A61pBvOV-zkIrYZKDTagNbFrm6HxyFbuwCLcBGAs/s1600/bern.png" style="margin-left: 1em; margin-right: 1em;"><img border="0" src="https://4.bp.blogspot.com/-n0Xj6fdNu-g/W5UZE-Z0O8I/AAAAAAAAlFM/A61pBvOV-zkIrYZKDTagNbFrm6HxyFbuwCLcBGAs/s640/bern.png" width="600"></a></div>
@@ -454,7 +454,7 @@ latest fashion at the time, at least for a little while.</p></li>
 observing and logging the execution of the running program. This yields a
 straight-line trace of operations, which are then optimized and compiled into
 machine code. Of course most tracing systems mostly focus on tracing loops.</p>
-<p>As we discovered, it's actually quite simple to <a class="reference external" href="https://morepypy.blogspot.com/2009/03/applying-tracing-jit-to-interpreter.html">apply a tracing JIT to a generic
+<p>As we discovered, it's actually quite simple to <a class="reference external" href="https://www.pypy.org/posts/2009/03/applying-tracing-jit-to-interpreter.html">apply a tracing JIT to a generic
 interpreter</a>, by not tracing the execution of the user program directly, but by
 instead tracing the execution of the interpreter while it is running the user
 program (here's the <a class="reference external" href="https://foss.heptapod.net/pypy/extradoc/-/blob/branch/default/default/talk/icooolps2009/bolz-tracing-jit-final.pdf">paper</a> we wrote about this approach).</p>
@@ -497,7 +497,7 @@ Antonio Cuni and I, had started working for universities and other project
 members had other sources of funding). But again, while we did the work it
 became clear that to get an actually working fast PyPy with generated JIT we
 would need actual funding again for the project. So we applied to the EU again,
-this time for a much smaller project with less money, in the <a class="reference external" href="https://morepypy.blogspot.com/2010/12/oh-and-btw-pypy-gets-funding-through.html">Eurostars</a>
+this time for a much smaller project with less money, in the <a class="reference external" href="https://www.pypy.org/posts/2010/12/oh-and-btw-pypy-gets-funding-through.html">Eurostars</a>
 framework. We got a grant for three participants, <a class="reference external" href="https://merlinux.eu/">merlinux</a>, <a class="reference external" href="https://www.openend.se/">OpenEnd</a> and Uni
 Düsseldorf, on the order of a bit more than half a million euro. That money was
 specifically for JIT development and JIT testing infrastructure.</p>
@@ -574,7 +574,7 @@ structures. I am going to write about two exemplary ones here, maps and storage 
 Javascript objects, in that you can add arbitrary attributes to them at runtime.
 Originally Python instances were backed by a dictionary in PyPy, but of course
 in practice most instances of the same class have the same set of attribute
-names. Therefore we went and implemented <a class="reference external" href="https://morepypy.blogspot.com/2010/11/efficiently-implementing-python-objects.html">Self style maps</a>, which are often
+names. Therefore we went and implemented <a class="reference external" href="https://www.pypy.org/posts/2010/11/efficiently-implementing-python-objects.html">Self style maps</a>, which are often
 called <a class="reference external" href="https://richardartoul.github.io/jekyll/update/2015/04/26/hidden-classes.html">hidden classes</a> in the JS world to represent instances instead. This
 has two big benefits, it allows you to generate much better machine code for
 instance attribute access and makes instances use a lot less memory.</p>
@@ -589,7 +589,7 @@ data structures, such as lists, dictionaries and sets. A fairly straightforward
 observation about how those are used is that in a significant percentage of
 cases they contain type-homogeneous data. As an example it's quite common to
 have lists of only integers, or lists of only strings. So we changed the list,
-dict and set implementations to use something we called <a class="reference external" href="https://morepypy.blogspot.com/2011/10/more-compact-lists-with-list-strategies.html">storage strategies</a>. With
+dict and set implementations to use something we called <a class="reference external" href="https://www.pypy.org/posts/2011/10/more-compact-lists-with-list-strategies.html">storage strategies</a>. With
 storage strategies these data structures use a more efficient representations if
 they contain only primitives of the same type, such as ints, floats, strings.
 This makes it possible to store the values without boxing them in the underlying
@@ -626,7 +626,7 @@ away". That never works very well.</p>
 <p>So, here we are at the end of the Eurostars project, what's the status of the JIT? Well, it
 seems this meta-tracing stuff really works! We finally started actually
 believing in it, when we reached the point in 2010 where self-hosting PyPy was
-actually <a class="reference external" href="https://morepypy.blogspot.com/2010/11/snake-which-bites-its-tail-pypy-jitting.html">faster</a> than bootstrapping the VM on CPython. Speeding up the
+actually <a class="reference external" href="https://www.pypy.org/posts/2010/11/snake-which-bites-its-tail-pypy-jitting.html">faster</a> than bootstrapping the VM on CPython. Speeding up the
 bootstrapping process is something that Psyco never managed at all, so we
 considered this a quite important achievement. At the end of
 Eurostars, we were about 4x faster than CPython on our set of benchmarks.</p>
@@ -641,17 +641,17 @@ sources of funding: we received some crowd funding via the <a class="reference e
 Conservancy</a> and contracts of various sizes from companies to implement various
 specific features, often handled by <a class="reference external" href="https://baroquesoftware.com/">Baroque Software</a>. Over the next couple of
 years
-we revamped various parts of the VM. We improved the GC in <a class="reference external" href="https://morepypy.blogspot.com/2013/10/incremental-garbage-collector-in-pypy.html">major</a> ways. We
-optimized the implementation of the JIT compiler to improve <a class="reference external" href="https://morepypy.blogspot.com/2015/10/pypy-memory-and-warmup-improvements-2.html">warmup</a> <a class="reference external" href="https://morepypy.blogspot.com/2016/04/warmup-improvements-more-efficient.html">times</a>. We
-implemented backends for various CPU architectures (including <a class="reference external" href="https://morepypy.blogspot.com/2015/10/powerpc-backend-for-jit.html">PowerPC</a> and
-<a class="reference external" href="https://morepypy.blogspot.com/2016/04/pypy-enterprise-edition.html">s390x</a>). We tried to reduce the number of performance cliffs and make the JIT
+we revamped various parts of the VM. We improved the GC in <a class="reference external" href="https://www.pypy.org/posts/2013/10/incremental-garbage-collector-in-pypy.html">major</a> ways. We
+optimized the implementation of the JIT compiler to improve <a class="reference external" href="https://www.pypy.org/posts/2015/10/pypy-memory-and-warmup-improvements-2.html">warmup</a> <a class="reference external" href="https://www.pypy.org/posts/2016/04/warmup-improvements-more-efficient.html">times</a>. We
+implemented backends for various CPU architectures (including <a class="reference external" href="https://www.pypy.org/posts/2015/10/powerpc-backend-for-jit.html">PowerPC</a> and
+<a class="reference external" href="https://www.pypy.org/posts/2016/04/pypy-enterprise-edition.html">s390x</a>). We tried to reduce the number of performance cliffs and make the JIT
 useful in a broader set of cases.</p>
 <p>Another strand of work was to push quite significantly to be more
 compatible with CPython, particularly the Python 3 line as well as extension
 module support. Other compatibility improvements we did was making sure that
-virtualenv <a class="reference external" href="https://morepypy.blogspot.com/2010/08/using-virtualenv-with-pypy.html">works with PyPy</a>, better support for distutils and setuptools and
+virtualenv <a class="reference external" href="https://www.pypy.org/posts/2010/08/using-virtualenv-with-pypy.html">works with PyPy</a>, better support for distutils and setuptools and
 similar improvements. The continually improving performance as well better
-compatibility with the ecosystem tools led to the <a class="reference external" href="https://morepypy.blogspot.com/2014/10/couchbase-contribution-to-pypy.html">first few</a> <a class="reference external" href="https://baroquesoftware.com/blog#interview-with-roberto_de_ioris">users</a> of PyPy in
+compatibility with the ecosystem tools led to the <a class="reference external" href="https://www.pypy.org/posts/2014/10/couchbase-contribution-to-pypy.html">first few</a> <a class="reference external" href="https://baroquesoftware.com/blog#interview-with-roberto_de_ioris">users</a> of PyPy in
 <a class="reference external" href="https://baroquesoftware.com/blog#magnetic">industry</a>.</p>
 </div>
 <div class="section" id="cpyext">
@@ -663,17 +663,17 @@ was CPyExt. One of the main blockers of PyPy adoption had always been the fact
 that a lot of people need specific C-extension modules at least in some parts of
 their program, and telling them to reimplement everything in Python is just not
 a practical solution. Therefore we worked on CPyExt, an emulation layer  to make
-it possible to run <a class="reference external" href="https://morepypy.blogspot.com/2010/04/using-cpython-extension-modules-with.html">CPython C-extension modules</a> in PyPy. Doing that was a very
+it possible to run <a class="reference external" href="https://www.pypy.org/posts/2010/04/using-cpython-extension-modules-with.html">CPython C-extension modules</a> in PyPy. Doing that was a very
 <a class="reference external" href="https://www.youtube.com/watch?v=qH0eeh-4XE8">painful process</a>, since the CPython extension API leaks a lot of CPython
 implementation details, so we had to painstakingly emulate all of these details
 to make it possible to run extensions. That this works at all remains completely
 amazing to me! But nowadays CPyExt is even getting quite good, a lot of the big
-numerical libraries such as Numpy and <a class="reference external" href="https://morepypy.blogspot.com/2017/10/pypy-v59-released-now-supports-pandas.html">Pandas</a> are now supported (for a while
+numerical libraries such as Numpy and <a class="reference external" href="https://www.pypy.org/posts/2017/10/pypy-v59-released-now-supports-pandas.html">Pandas</a> are now supported (for a while
 we had worked hard on a reimplementation of Numpy called NumPyPy, but
 eventually realized that it would never be complete and useful enough).
 However, calling CPyExt modules from PyPy can still be very slow,
 which makes it impractical for some applications
-that's why we are <a class="reference external" href="https://morepypy.blogspot.com/2017/10/cape-of-good-hope-for-pypy-hello-from.html">working</a> on it.</p>
+that's why we are <a class="reference external" href="https://www.pypy.org/posts/2017/10/cape-of-good-hope-for-pypy-hello-from.html">working</a> on it.</p>
 <p>Not thinking about C-extension module emulation earlier in the project history
 was a pretty bad strategic mistake. It had been clear for a long time that
 getting people to just stop using all their C-extension modules was never going
@@ -690,7 +690,7 @@ of emulation was going to be practical, until somebody <a class="reference exter
 <p>Another main
 focus of the last couple of years has been to catch up with the CPython 3 line.
 Originally we had ignored Python 3 for a little bit too long, and were trailing
-several versions behind. In 2016 and 2017 we had a <a class="reference external" href="https://morepypy.blogspot.com/2016/08/pypy-gets-funding-from-mozilla-for.html">grant</a> from the Mozilla open
+several versions behind. In 2016 and 2017 we had a <a class="reference external" href="https://www.pypy.org/posts/2016/08/pypy-gets-funding-from-mozilla-for.html">grant</a> from the Mozilla open
 source support program of $200'000 to be able to catch up with Python 3.5. This
 work is now basically done, and we are starting to target CPython 3.6 and will
 have to look into 3.7 in the near future.</p>

--- a/posts/2018/09/the-first-15-years-of-pypy-3412615975376972020.html
+++ b/posts/2018/09/the-first-15-years-of-pypy-3412615975376972020.html
@@ -123,7 +123,7 @@ calls to do the stack manipulations:</p>
         <span class="keyword">raise</span> <span class="name">FailedToImplement</span><span class="punctuation">(</span><span class="name">space</span><span class="operator">.</span><span class="name">w_OverflowError</span><span class="punctuation">,</span>
                                 <span class="name">space</span><span class="operator">.</span><span class="name">wrap</span><span class="punctuation">(</span><span class="literal string double">"integer addition"</span><span class="punctuation">))</span>
     <span class="keyword">return</span> <span class="name">W_IntObject</span><span class="punctuation">(</span><span class="name">space</span><span class="punctuation">,</span> <span class="name">z</span><span class="punctuation">)</span></code></pre>
-<p>(the <a class="reference external" href="https://bitbucket.org/pypy/pypy/src/090965df249b458918fbcbd0a407b40d2a3d29b4/pypy/interpreter/pyopcode.py?at=default&amp;fileviewer=file-view-default#pyopcode.py-577">current</a> <a class="reference external" href="https://bitbucket.org/pypy/pypy/src/090965df249b458918fbcbd0a407b40d2a3d29b4/pypy/objspace/std/intobject.py?at=default&amp;fileviewer=file-view-default#intobject.py-561">implementations</a> look slightly but not fundamentally different.)</p>
+<p>(the <a class="reference external" href="https://foss.heptapod.net/pypy/pypy/-/blob/branch/default/pypy/interpreter/pyopcode.py#L582">current</a> <a class="reference external" href="https://foss.heptapod.net/pypy/pypy/-/blob/branch/default/pypy/objspace/std/intobject.py#L551">implementations</a> look slightly but not fundamentally different.)</p>
 </div>
 
 
@@ -681,7 +681,7 @@ to work, despite our efforts to give them alternatives, such as <a class="refere
 should have thought of a story for all the existing C-extension modules earlier
 in the project. Not starting CPyExt earlier was mostly a failure of our
 imagination (and maybe a too high pain threshold): We didn't believe this kind
-of emulation was going to be practical, until somebody <a class="reference external" href="https://bitbucket.org/pypy/pypy/commits/e30d69f4dedc">went and tried it</a>.</p>
+of emulation was going to be practical, until somebody <a class="reference external" href="https://foss.heptapod.net/pypy/pypy/-/commit/0c718ff5a3c1b583179325ab27b0d3b17fa11c0c">went and tried it</a>.</p>
 </div>
 
 

--- a/posts/2018/09/the-first-15-years-of-pypy-3412615975376972020.meta
+++ b/posts/2018/09/the-first-15-years-of-pypy-3412615975376972020.meta
@@ -1,7 +1,7 @@
 .. title: The First 15 Years of PyPy — a Personal Retrospective
 .. slug: the-first-15-years-of-pypy-3412615975376972020
 .. date: 2018-09-09 14:50:00
-.. tags: 
+.. tags: roadmap
 .. description: 
 .. authors: Carl Friedrich Bolz-Tereick
 .. id: 3412615975376972020

--- a/posts/2019/01/pypy-for-low-latency-systems-613165393301401965.html
+++ b/posts/2019/01/pypy-for-low-latency-systems-613165393301401965.html
@@ -83,7 +83,7 @@ is not as bad as it could sound.<br>
 <br>
 Combining these two functions, it is possible to take control of the GC to
 make sure it runs only when it is acceptable to do so.  For an example of
-usage, you can look at the implementation of a <a class="reference external" href="https://bitbucket.org/antocuni/pypytools/src/0273afc3e8bedf0eb1ef630c3bc69e8d9dd661fe/pypytools/gc/custom.py?at=default&amp;fileviewer=file-view-default">custom GC</a> inside <a class="reference external" href="https://pypi.org/project/pypytools/">pypytools</a>.
+usage, you can look at the implementation of a <a class="reference external" href="https://github.com/antocuni/pypytools/blob/master/pypytools/gc/custom.py">custom GC</a> inside <a class="reference external" href="https://pypi.org/project/pypytools/">pypytools</a>.
 The peculiarity is that it also defines a "<tt class="docutils literal">with <span class="pre">nogc():"</span></tt> context manager
 which you can use to mark performance-critical sections where the GC is not
 allowed to run.<br>

--- a/posts/2022/04/how-is-pypy-tested.rst
+++ b/posts/2022/04/how-is-pypy-tested.rst
@@ -61,7 +61,7 @@ PyPy Testing History
 
 A few historical notes on the PyPy project and its relationship to testing: The
 PyPy project `was started in 2004`_. At the time when the project was started,
-Extreme Programming and Agile Software Development where up and coming. On the
+Extreme Programming and Agile Software Development were up and coming. On the
 methodology side, PyPy was heavily influenced by these, and started using
 Test-Driven Development and pair programming right from the start.
 


### PR DESCRIPTION
Looking at the latest blogpost, it referenced an older post that still had bitbucket links. So I did some cleanup.