### PR TITLE
change macosx -> macos, macosx is obsolete

### DIFF
--- a/posts/2022/07/m1-support-for-pypy.txt
+++ b/posts/2022/07/m1-support-for-pypy.txt
@@ -8,19 +8,19 @@
 .. type: rest
 .. author: The PyPy Team
 
-The PyPy team is happy to announce that we can now target the macOSX ARM64
+The PyPy team is happy to announce that we can now target the macOS ARM64
 platform. Much of the work was executed by Maciej Fijałkowski (fijal) and
 funded via a generous contribution to our OpenCollective_. The work is based
 on our existing :doc:`support for aarch64
 <pypy-jit-for-aarch64-7161523403247118006>` (arm64 on linux) with some twists
 to support the differences between the CPUs and the operating system. There
-are nightly builds for pypy3.8_ and pypy3.9_ (look for ``macosx_arm64``), and
+are nightly builds for pypy3.8_ and pypy3.9_ (look for ``macos_arm64``), and
 the architecture will be part of our next release.
 
 Please try it out and let us know how it is useful for you or how we could
 improve.
 
-We still need help improving our macOSX support. We have an `open issue`_ to
+We still need help improving our macOS support. We have an `open issue`_ to
 help our packaging story. Help is welcome.
 
 The PyPy team.


### PR DESCRIPTION
Someone on [reddit](https://www.reddit.com/r/Python/comments/w5c7dx/comment/ih7fcb3/?utm_source=reddit&utm_medium=web2x&context=3) pointed out that macosx is no longer a thing, it became "Mac OS X" then macOS. This can be merged only after we restart the buildbot (to change the upload name) and run the builds once so that the nightly download name will update.