### PR TITLE
add a cname directive to the ghp-import command

### DIFF
--- a/.github/workflows/nikola.yml
+++ b/.github/workflows/nikola.yml
@@ -2,7 +2,7 @@
 
 name: Nikola
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
@@ -31,4 +31,4 @@ jobs:
       run: |
         # reuse the venv
         venv_nikola/bin/python -m pip install ghp-import
-        venv_nikola/bin/ghp-import -m"Automatic push by ghp-import" -f -p -r origin -b gh-pages public
+        venv_nikola/bin/ghp-import -m"Automatic push by ghp-import" -f -p -r origin -b gh-pages --cname=pypy.org public


### PR DESCRIPTION
Related to #120, needed to preserve the CNAME file in the gh-pages branch when using ghp-import.

Merge once the DNS has changed from the PSF infrastructure to github infrastructure. cc @fijal