### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ venv_nikola/bin/nikola`, then `./venv_nikola/bin/nikola new_post`.
 
 After you make changes, you can do `make build` to regenerate the pages in
 ``public/`` for local viewing, but **do not commit these**, they will be
-rebuilt and commited via a CI deploy step. You can also do ``make auto`` to
+rebuilt and committed via a CI deploy step. You can also do ``make auto`` to
 start a server that will serve the pages, and rebuild them when any changes are
 made to the sources.
 

--- a/pages/download_advanced.rst
+++ b/pages/download_advanced.rst
@@ -91,7 +91,7 @@ We provide pre-compiled binaries for many platforms and OSes:
   table finish
 
 
-.. list-table:: Other Platfoms
+.. list-table:: Other Platforms
    :widths: 20 15 15 35
    :header-rows: 1
 
@@ -246,7 +246,7 @@ a symlink to it, otherwise it will not find its libraries.
 Installing more modules
 -----------------------
 
-The tpyical ``pip`` workflow for packages with binary extensions
+The typical ``pip`` workflow for packages with binary extensions
 requires that the package maintainers provide a wheel for PyPy, which is
 sometimes too much work for the overburdened maintainers. For more information
 see the `installation documentation_`

--- a/pages/people.rst
+++ b/pages/people.rst
@@ -117,7 +117,7 @@ Holger Krekel
 .. image:: images/people/holger1.jpg
 
 Holger Krekel is a founder of the PyPy project and has participated in
-PyPy core developement for several years as well as maintained much of
+PyPy core development for several years as well as maintained much of
 its infrastructure.  He also is the author of the popular `py.test`_ and
 `tox`_ testing tools as well as execnet_, a library for easily deploying
 different interacting Python interpreters side by side.  He helped

--- a/pages/pypy-sponsors.md
+++ b/pages/pypy-sponsors.md
@@ -11,7 +11,7 @@
 -->
 
 Keeping a project as ambitious as PyPy requires resources. Sometimes the
-problems encoutered are general, like updating python versions or supporting
+problems encountered are general, like updating python versions or supporting
 various c-extensions. Sometimes the problems are specific and require precise
 solutions that may not generalize to all users. Likewise, sponsorship of PyPy
 can be general or specific.

--- a/posts/2021/04/some-uses-of-graphviz.txt
+++ b/posts/2021/04/some-uses-of-graphviz.txt
@@ -100,7 +100,7 @@ that for the callgraphs above).
 
 All in all this is a really powerful approach to understand the behaviour of
 some of code, or when debugging complicated problems and we have gotten a
-huge amount of milage out of this over the years. It can be seen as an instance
+huge amount of mileage out of this over the years. It can be seen as an instance
 of `moldable development`_ ("a way of programming through which you construct
 custom tools for each problem"). And it's really easy to get into! The Graphviz
 language is quite a simple text-based language that can be applied to a huge

--- a/posts/2021/05/pypy-v735-release.rst
+++ b/posts/2021/05/pypy-v735-release.rst
@@ -17,7 +17,7 @@ PyPy 7.3.4 was the first release that runs on windows 64-bit, so that support
 is still "beta". We are releasing it in the hopes that we can garner momentum
 for its continued support, but are already aware of some problems, for instance
 it errors in the NumPy test suite (issue 3462_). Please help out with testing
-the releae and reporting successes and failures, financially supporting our
+the release and reporting successes and failures, financially supporting our
 ongoing work, and helping us find the source of these problems.
 
 - The new windows 64-bit builds improperly named c-extension modules

--- a/posts/2021/10/pypy-v737-release.rst
+++ b/posts/2021/10/pypy-v737-release.rst
@@ -26,7 +26,7 @@ Additionally, a few smaller bugs were fixed:
 
 - Use ``uint`` for the ``request`` argument of ``fcntl.ioctl`` (issue 3568_)
 - Fix incorrect tracing of `while True`` body in 3.8 (issue 3577_)
-- Properly close resources when using a ``conncurrent.futures.ProcessPool``
+- Properly close resources when using a ``concurrent.futures.ProcessPool``
   (issue 3317_)
 - Fix the value of ``LIBDIR`` in ``_sysconfigdata`` in 3.8 (issue 3582_)
 

--- a/posts/2022/12/pypy-v7311-release.txt
+++ b/posts/2022/12/pypy-v7311-release.txt
@@ -15,7 +15,7 @@ PyPy v7.3.11: release of python 2.7, 3.8, and 3.9
 The PyPy team is proud to release version 7.3.11 of PyPy. As could be expected,
 the first release of macOS arm64 impacted the macOS x86-64 build, so this is
 a bug release to restore the ability of macOS users to run PyPy on
-``macOS < 11.0``. It also incoporates the latest CPython stdlib updates
+``macOS < 11.0``. It also incorporates the latest CPython stdlib updates
 released the day after 7.3.10 went out, and a few more bug fixes. The release
 includes three different interpreters:
 

--- a/posts/2023/12/pypy-moved-to-git-github.md
+++ b/posts/2023/12/pypy-moved-to-git-github.md
@@ -102,9 +102,9 @@ Note that the branches were named `branches/XXX` by the migration, not `branch/X
 I used the solution from
 [node-gitlab-2-github](https://github.com/piceaTech/node-gitlab-2-github) which
 worked almost perfectly. It is important to do the conversion on a __private
-repo__ otherwise every mention of a sucessfully mapped user name notifies
+repo__ otherwise every mention of a successfully mapped user name notifies
 the user about the transfer. This can be quite annoying for a repo the size of
-PyPy with 600 merge requests and over 4000 issues. Issues transfered without a
+PyPy with 600 merge requests and over 4000 issues. Issues transferred without a
 problem: the script properly retained the issue numbers. However the script
 does not convert the Mercurial hashes to Git hashes, so the bare hashes in
 comments show up without a link to the commit. Merge requests are more of a problem:
@@ -128,7 +128,7 @@ Heptapod" from this transition.
 ## Credits
 We would like to express our gratitude to the [Octobus](https://octobus.net/)
 team who support Heptapod. The transition from Bitbucket was quite an effort,
-and they have generously hosted our developement since then. We wish them all
+and they have generously hosted our development since then. We wish them all
 the best, and still believe that Mercurial should have "won".
 
 ## Next steps

--- a/posts/2023/12/pypy-v7314-release.txt
+++ b/posts/2023/12/pypy-v7314-release.txt
@@ -14,7 +14,7 @@ PyPy v7.3.14: release of python 2.7, 3.9, and 3.10
 
 The PyPy team is proud to release version 7.3.14 of PyPy.
 
-Hightlights of this release are compatibility with HPy-0.9_, cffi 1.16,
+Highlights of this release are compatibility with HPy-0.9_, cffi 1.16,
 additional C-API interfaces, and more python3.10 fixes.
 
 The release includes three different interpreters:

--- a/posts/2024/03/fixing-bug-incremental-gc.md
+++ b/posts/2024/03/fixing-bug-incremental-gc.md
@@ -324,7 +324,7 @@ yet.
 ## Writing a GC fuzzer/property based test
 
 Finding bugs in the GC is always extremely disconcerting, particularly since
-this one manged to hide for so long (more than ten years!). Therefore I wanted
+this one managed to hide for so long (more than ten years!). Therefore I wanted
 to use these bugs as motivation to try to find more problems in PyPy's GC. Given
 the ridiculous effectiveness of fuzzing, I used
 [hypothesis](https://hypothesis.readthedocs.io/en/latest/) to write a

--- a/posts/2024/05/vmprof-firefox.md
+++ b/posts/2024/05/vmprof-firefox.md
@@ -26,7 +26,7 @@ Those so far could give you some general visualizations of your profile, but do 
 To bring all of those features together in one tool, you may take a look at the vmprof-firefox-converter.
 
 Created in the context of my bachelor's thesis, the vmprof-firefox-converter is a tool for analyzing VMProf profiles with the [Firefox profiler](https://profiler.firefox.com/) user interface. 
-Instead of building a new user interface from scratch, this allows us to re-use the user interface work Mozilla put into the Firefox profiler.
+Instead of building a new user interface from scratch, this allows us to reuse the user interface work Mozilla put into the Firefox profiler.
 The Firefox profiler offers a timeline where you can zoom into profiles and work with different visualizations like a flame graph or a stack chart.
 To understand why there is time spent inside a function, you can revisit the source code and even dive into the intermediate representation of functions executed by PyPy's just-in-time compiler.
 Additionally, there is a visualization for PyPy's log output, to keep track whether PyPy spent time inside the interpreter, JIT or GC throughout the profiling time.

--- a/posts/2024/07/mining-jit-traces-missing-optimizations-z3.md
+++ b/posts/2024/07/mining-jit-traces-missing-optimizations-z3.md
@@ -22,7 +22,7 @@ inefficient integer operations in those traces.
 Starting from the optimized traces of real programs has some big
 advantages over the "classical" superoptimization approach of generating and
 then trying all possible sequences of instructions. It avoids the
-combinatorical explosion that happens with the latter approach. Also, starting
+combinatorial explosion that happens with the latter approach. Also, starting
 from the traces of benchmarks or (even better) actual programs makes sure that
 we actually care about the missing optimizations
 that are found in this way. And because the traces are analyzed after they have

--- a/posts/2024/07/toy-abstract-interpretation.md
+++ b/posts/2024/07/toy-abstract-interpretation.md
@@ -31,7 +31,7 @@ we did [some more heap optimizations][toy-heap].
 
 [toy-heap]: https://www.youtube.com/watch?v=w-UHg0yOPSE
 
-In this blog post, I'm going to write a small abtract interpreter for the Toy
+In this blog post, I'm going to write a small abstract interpreter for the Toy
 IR and then show how we can use it to do some simple optimizations. It assumes
 that you are familiar with the little IR, which I have reproduced unchanged in
 [a GitHub Gist][toy-ir].

--- a/posts/2024/08/toy-knownbits.md
+++ b/posts/2024/08/toy-knownbits.md
@@ -293,7 +293,7 @@ def test_contains():
 
 Now that we have implemented the basics of the `KnownBits` class, we need to
 start implementing the transfer functions. They are for computing what we know
-about the *results* of an operation, given the knownledge we have about the bits
+about the *results* of an operation, given the knowledge we have about the bits
 of the arguments.
 
 We'll start with a simple unary operation, `invert(x)` (which is `~x` in Python
@@ -729,7 +729,7 @@ Here's an attempt to do this manually in the Python repl:
 >>>> # like last blog post, proof by failing to find counterexamples
 >>>> def prove(cond): assert solver.check(z3.Not(cond)) == z3.unsat
 >>>>
->>>> # let's set up a z3 bitvector variable for an abitrary concrete value
+>>>> # let's set up a z3 bitvector variable for an arbitrary concrete value
 >>>> n1 = z3.BitVec('concrete_value', 64)
 >>>> n1
 concrete_value
@@ -1493,7 +1493,7 @@ constant folding, and to implement conditional peephole rewrites.
 
 In the next posts I'll write about the real implementation of a knownbits
 domain in PyPy's JIT, its combination with the existing interval abstract
-domain, how to deal with gaining informations from conditions in the program,
+domain, how to deal with gaining information from conditions in the program,
 and some lose ends.
 
 Sources:


### PR DESCRIPTION
# https://pypi.org/project/codespell
% `codespell --ignore-words-list=gameboy,ist,mata,nd,openend,theses --quiet=3 --skip="./archive/*,*.html,*.js"`
```
./README.md:19: commited ==> committed
./posts/2022/12/pypy-v7311-release.txt:18: incoporates ==> incorporates
./posts/2024/03/fixing-bug-incremental-gc.md:327: manged ==> managed
./posts/2024/05/vmprof-firefox.md:29: re-use ==> reuse
./posts/2024/07/mining-jit-traces-missing-optimizations-z3.md:25: combinatorical ==> combinatorial
./posts/2024/07/toy-abstract-interpretation.md:34: abtract ==> abstract
./posts/2024/08/toy-knownbits.md:296: knownledge ==> knowledge
./posts/2024/08/toy-knownbits.md:732: abitrary ==> arbitrary
./posts/2024/08/toy-knownbits.md:1496: informations ==> information
./posts/2023/12/pypy-moved-to-git-github.md:105: sucessfully ==> successfully
./posts/2023/12/pypy-moved-to-git-github.md:107: transfered ==> transferred
./posts/2023/12/pypy-moved-to-git-github.md:131: developement ==> development
./posts/2023/12/pypy-v7314-release.txt:17: Hightlights ==> Highlights
./posts/2021/04/some-uses-of-graphviz.txt:103: milage ==> mileage
./posts/2021/05/pypy-v735-release.rst:20: releae ==> release
./posts/2021/10/pypy-v737-release.rst:29: conncurrent ==> concurrent
./pages/download_advanced.rst:94: Platfoms ==> Platforms
./pages/download_advanced.rst:249: tpyical ==> typical
./pages/people.rst:120: developement ==> development
./pages/pypy-sponsors.md:14: encoutered ==> encountered
```
% `codespell --ignore-words-list=gameboy,ist,mata,nd,openend,theses --quiet=3 --skip="./archive/*,*.html,*.js --write-changes"`

Removing `*.html` from `--skip` would show approx 140 more typos.