### PR TITLE
Add pre-commit to run codespell and other tools

### DIFF
--- a/.github/workflows/nikola.yml
+++ b/.github/workflows/nikola.yml
@@ -20,11 +20,6 @@ jobs:
     - name: Check valid checksums
       shell: bash
       run: python3 check_checksums.py
-    - name: Look for typos with codespell
-      shell: bash
-      run: |
-        pip install --user codespell[toml]
-        codespell --ignore-words-list=gameboy,ist,mata,nd,openend,theses --quiet=3 --skip="./archive/*,*.html,*.js"
     - name: Build docs
       shell: bash
       run: |
@@ -37,3 +32,12 @@ jobs:
         # reuse the venv
         venv_nikola/bin/python -m pip install ghp-import
         venv_nikola/bin/ghp-import -m"Automatic push by ghp-import" -f -p -r origin -b gh-pages --cname=pypy.org public
+
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+    - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,52 @@
+# Learn more about this config here: https://pre-commit.com/
+
+# To enable these pre-commit hooks run:
+# `pipx install pre-commit` or `brew install pre-commit`
+# Then in the project root directory run `pre-commit install`
+
+# default_language_version:
+#   python: python3
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-byte-order-marker
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-xml
+      - id: check-yaml
+      - id: debug-statements
+      - id: destroyed-symlinks
+      - id: detect-private-key
+      - id: file-contents-sorter
+      - id: fix-byte-order-marker
+      - id: forbid-new-submodules
+      - id: forbid-submodules
+      - id: mixed-line-ending
+      - id: name-tests-test
+      - id: pretty-format-json
+      - id: requirements-txt-fixer
+      - id: sort-simple-yaml
+      # - id: check-builtin-literals
+      # - id: check-shebang-scripts-are-executable
+      # - id: check-vcs-permalinks
+      # - id: double-quote-string-fixer
+      # - id: end-of-file-fixer
+      # - id: fix-encoding-pragma
+      # - id: no-commit-to-branch
+      # - id: trailing-whitespace
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        args: ["--toml=pyproject.toml"]
+        additional_dependencies:
+          - tomli

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: build
 
 venv_nikola/bin/nikola:  ## create a virtualenv to build the website
 > @virtualenv -ppython3 ./venv_nikola
-> @venv_nikola/bin/python -mpip install nikola==8.2.2 markdown==3.3 jinja2 aiohttp watchdog ruamel.yaml feedparser codespell
+> @venv_nikola/bin/python -mpip install nikola==8.2.2 markdown==3.3 jinja2 aiohttp watchdog ruamel.yaml feedparser codespell tomli
 > @venv_nikola/bin/nikola plugin -i sidebar
 > @venv_nikola/bin/nikola plugin -i localsearch
 
@@ -25,7 +25,7 @@ plugins/import_blogger: venv_nikola/bin/nikola
 
 codespell: venv_nikola/bin/nikola  ## check and fix typos
 # If codespell is not found, rerun `make venv_nikola/bin/nikola`
-> venv_nikola/bin/codespell --ignore-words-list=gameboy,ist,mata,nd,openend,theses --quiet=3 --skip="./venv_nikola/*,./archive/*,*.html,*.js,./public" --write-changes
+> venv_nikola/bin/codespell --toml=pyproject.toml --write-changes
 
 build: codespell  ## build the website if needed, the result is in ./public
 > venv_nikola/bin/nikola build
@@ -60,4 +60,3 @@ help:   ## Show this help.
 > @echo "\nHelp for building the website, based on nikola"
 > @echo "Possible commands are:"
 > @grep -h "##" $(MAKEFILE_LIST) | grep -v grep | sed -e 's/\(.*\):.*##\(.*\)/    \1: \2/'
- 

--- a/plugins/static_comments/static_comments.py
+++ b/plugins/static_comments/static_comments.py
@@ -211,7 +211,7 @@ class StaticComments(SignalHandler):
                 # make sure this is a comment to "file"
                 if not filename[1:].startswith(post_base + '-comment'):
                     continue
-                # There is both a *.mata and a *.html. Send only the base of
+                # There is both a *.meta and a *.html. Send only the base of
                 # the *.meta for parsing
                 parts = filename.rsplit('.', 1)
                 if parts[1] != 'meta':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.codespell]
+ignore-words-list = "gameboy,ist,nd,openend,theses"
+quiet-level = 3
+skip = "*.html,*.js,./.*,./archive/*,./venv_nikola,archive/*"


### PR DESCRIPTION
Use the https://pre-commit.com tool to set up localhost and GitHub Actions testing of codespell and other tools.

Enable some standard hooks while leaving others commented out to facilitate enabling them in future pull requests.

Migrate the codespell settings into `pyproject.toml` ~and add hooks for validation and formatting of this file~.

https://github.com/pre-commit-ci/lite-action is used to run the tests on pull requests.  https://pre-commit.ci does more.