### PR TITLE
announce move to manylinux2_28 builds

### DIFF
--- a/pages/download.rst
+++ b/pages/download.rst
@@ -14,7 +14,8 @@ We provide pre-compiled binaries for many platforms and OSes.
   Our `nightly binary builds`_ have the most recent bugfixes and performance
   improvements, though they can be less stable than the official releases. See
   these links for `other versions`_ or `more information`_ including other
-  platforms.
+  platforms. Note that as of mid-July 2026, the nightly builds for linux require
+  ``GLBIC>=2.28`` (they build on ``manylinux2_28`` containers)
 
 .. _`nightly binary builds`: https://buildbot.pypy.org/nightly/
 .. _`other versions`: https://downloads.python.org/pypy/

--- a/pages/download_advanced.rst
+++ b/pages/download_advanced.rst
@@ -19,7 +19,9 @@ We provide pre-compiled binaries for many platforms and OSes:
 
   Our `nightly binary builds`_ have the most recent bugfixes and performance
   improvements, though they can be less stable than the official releases. See
-  this link for `older versions`_.
+  this link for `older versions`_. Note that as of mid-July 2026, the nightly
+  builds for linux require ``GLBIC>=2.28`` (they build on ``manylinux2_28``
+  containers), which corresponds to CentOS8.
 
 .. _`nightly binary builds`: https://buildbot.pypy.org/nightly/
 .. _`older versions`: https://downloads.python.org/pypy/
@@ -42,7 +44,7 @@ We provide pre-compiled binaries for many platforms and OSes:
    * - **Linux x86 64 bit**
      - Download__
      - Download__
-     - compatible with CentOS7 and later.
+     - compatible with CentOS7 (manylinux2014) and later.
 
    * - **Windows 64 bit**
      - Download__
@@ -67,7 +69,7 @@ We provide pre-compiled binaries for many platforms and OSes:
 
      - Download__
      - Download__
-     - compatible with CentOS7 and later.
+     - compatible with CentOS7 (manylinux2014) and later.
 
 .. __: https://downloads.python.org/pypy/pypy3.11-v7.3.23-linux64.tar.bz2
 .. __: https://downloads.python.org/pypy/pypy2.7-v7.3.23-linux64.tar.bz2
@@ -104,7 +106,7 @@ We provide pre-compiled binaries for many platforms and OSes:
 
      - Download__
      - Download__
-     - compatible with CentOS7 and later
+     - compatible with CentOS7 (manylinux2014) and later
 
 .. __: https://downloads.python.org/pypy/pypy3.11-v7.3.23-linux32.tar.bz2
 .. __: https://downloads.python.org/pypy/pypy2.7-v7.3.23-linux32.tar.bz2

--- a/posts/2026/07/moving-linux-builds-to-glibc228.md
+++ b/posts/2026/07/moving-linux-builds-to-glibc228.md
@@ -1,0 +1,29 @@
+<!--
+.. title: Moving linux builds to GLIBC==2.28
+.. slug: moving-linux-builds-to-glibc228
+.. date: 2026-07-18 18:09:11 UTC
+.. tags: 
+.. category: 
+.. link: 
+.. description: 
+.. type: text
+.. author: mattip
+-->
+
+A short note for visibility.
+
+PyPy builds tarballs of the compiler [ready for
+download](https://downloads.python.org/pypy/). These include the latest
+releases and also nightly builds, fresh from our fleet of buildbots. Over the
+next couple of days, the nightly builds on linux will transition from
+`manylinux2014` based docker images [to `manylinux2_28`
+images](https://github.com/pypy/pypy-ci). The practical implication is that
+nightly images, and the next releases, will require a minimum of `GLIBC>=2.28`,
+i.e. AlmaLinux8, amanzonlinux 2023, debian 10, ubuntu 20.04. For a good
+overview of how this glibc/distro/manylinux all works, see [the PEP 600 compliance
+page](https://github.com/mayeut/pep600_compliance).
+
+The next release will indicate this change by a new PyPy major version, 8.0.0.
+It should include a Python3.12 interpreter, in which case it will be the last
+release of the Python 3.11 interpreter.
+

--- a/posts/2026/07/moving-linux-builds-to-glibc228.md
+++ b/posts/2026/07/moving-linux-builds-to-glibc228.md
@@ -12,7 +12,7 @@
 
 A short note for visibility.
 
-PyPy builds tarballs of the compiler [ready for
+PyPy builds tarballs of the python interpreter [ready for
 download](https://downloads.python.org/pypy/). These include the latest
 releases and also nightly builds, fresh from our fleet of buildbots. Over the
 next couple of days, the nightly builds on linux will transition from


### PR DESCRIPTION
Both a blog post and updates to the download page to announce we are moving from the depricated manylinux2014 images to manylinux2_28 on linux. This does not affect macos and windows tarballs (zipfiles). Note we now have a pypy-ci repo that builds the images in CI and hosts them at ghcr.io/pypy, which is a github container repo.